### PR TITLE
Prevent Duplicate Key Error when 'key' is passed into constructor.

### DIFF
--- a/lib/linkwell.dart
+++ b/lib/linkwell.dart
@@ -279,7 +279,6 @@ class LinkWell extends StatelessWidget {
         textScaleFactor: textScaleFactor,
         textWidthBasis: textWidthBasis,
         textDirection: textDirection,
-        key: key,
         text: TextSpan(children: textSpanWidget),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  url_launcher: ^5.4.5
+  url_launcher: ^6.0.2
+
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This change fixed an error with a duplicate key when the LinkWell widget is constructed passing in the 'key' value.

Error was:
Multiple widgets used the same GlobalKey.

This error never occurred unless the caller passed in a Key. It is easy in the old version to create this problem by just passing in a key in the constructor. The new version works correctly when passing in a key.