### PR TITLE
Added "enableTextSelection" property, Fixed error in running example, Removed redundant code

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.1.0'
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:linkwell/linkwell.dart';
@@ -6,7 +5,6 @@ import 'package:linkwell/linkwell.dart';
 void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -28,34 +26,28 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  
-  
   @override
   Widget build(BuildContext context) {
-
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
       ),
-      
       body: Container(
-        child:  Center(
+        child: Center(
           child: Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-
-                  SizedBox(
-                    height: 10,
-                  ),
-                  LinkWell(
-                    "Hi here's my email: samuelezedi@gmail.com and website: https://pronoun.com.ng",
-                  )
-                ],
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              SizedBox(
+                height: 10,
               ),
+              LinkWell(
+                "Hi here's my email: samuelezedi@gmail.com and website: https://pronoun.com.ng",
+                enableTextSelection: true,
+              )
+            ],
+          ),
         ),
-
-
       ),
     );
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -49,7 +49,7 @@ packages:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "1.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -85,7 +85,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.9"
+    version: "2.0.6"
   matcher:
     dependency: transitive
     description:
@@ -125,7 +125,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -160,7 +160,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,5 +1,8 @@
 name: example
 description: A new Flutter application.
+
+publish_to: 'none'
+
 version: 1.0.0+1
 
 environment:
@@ -11,7 +14,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
+  cupertino_icons: ^1.0.3
   linkwell:
     path: ../
 

--- a/lib/linkwell.dart
+++ b/lib/linkwell.dart
@@ -35,6 +35,10 @@ class LinkWell extends StatelessWidget {
   /// This hold the text the user provides
   final String text;
 
+  /// Enable text selection.
+  /// With enableTextSelection set to true LinkWell overflow and softWrap property won't work.
+  final bool enableTextSelection;
+
   /// This hold user defined styling
   /// It's an instanciation of Flutter Widget TextStyle
   final TextStyle? style;
@@ -117,6 +121,7 @@ class LinkWell extends StatelessWidget {
     this.strutStyle,
     this.listOfNames,
     this.textWidthBasis = TextWidthBasis.parent,
+    this.enableTextSelection = false,
   })  : assert(text != null),
         assert(textAlign != null),
         assert(softWrap != null),
@@ -229,7 +234,9 @@ class LinkWell extends StatelessWidget {
 
         var l = value.toString().contains('https://')
             ? value
-            : value.toString().contains('http://') ? value : 'http://' + value;
+            : value.toString().contains('http://')
+                ? value
+                : 'http://' + value;
         var name = l;
 
         if (this.listOfNames != null) {
@@ -269,18 +276,35 @@ class LinkWell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      child: RichText(
-        textAlign: textAlign,
-        locale: locale,
-        maxLines: maxLines,
-        overflow: overflow,
-        strutStyle: strutStyle,
-        softWrap: softWrap,
-        textScaleFactor: textScaleFactor,
-        textWidthBasis: textWidthBasis,
-        textDirection: textDirection,
-        text: TextSpan(children: textSpanWidget),
-      ),
+      child: enableTextSelection
+          ? SelectableText.rich(
+              TextSpan(
+                children: textSpanWidget,
+                style: TextStyle(
+                  locale: locale,
+                ),
+              ),
+              textAlign: textAlign,
+              maxLines: maxLines,
+              //overflow: overflow,
+              strutStyle: strutStyle,
+              //softWrap: softWrap,
+              textScaleFactor: textScaleFactor,
+              textWidthBasis: textWidthBasis,
+              textDirection: textDirection,
+            )
+          : RichText(
+              textAlign: textAlign,
+              locale: locale,
+              maxLines: maxLines,
+              overflow: overflow,
+              strutStyle: strutStyle,
+              softWrap: softWrap,
+              textScaleFactor: textScaleFactor,
+              textWidthBasis: textWidthBasis,
+              textDirection: textDirection,
+              text: TextSpan(children: textSpanWidget),
+            ),
     );
   }
 }

--- a/lib/linkwell.dart
+++ b/lib/linkwell.dart
@@ -122,13 +122,7 @@ class LinkWell extends StatelessWidget {
     this.listOfNames,
     this.textWidthBasis = TextWidthBasis.parent,
     this.enableTextSelection = false,
-  })  : assert(text != null),
-        assert(textAlign != null),
-        assert(softWrap != null),
-        assert(overflow != null),
-        assert(textScaleFactor != null),
-        assert(maxLines == null || maxLines > 0),
-        assert(textWidthBasis != null) {
+  }) : assert(maxLines == null || maxLines > 0) {
     /// At construction _initialize function is called
     _initialize();
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -111,7 +111,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -146,7 +146,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Added property "enableTextSelection" in LinkWell widget which allows text selection in the widget.
Fixed "No toolchains found in the NDK toolchains folder" error on running project example.
Removed redundant code and fixed warnings.
